### PR TITLE
`score-compose provisioners list` - `expected_outputs.name`

### DIFF
--- a/score-compose/10-redis-dapr-state-store.provisioners.yaml
+++ b/score-compose/10-redis-dapr-state-store.provisioners.yaml
@@ -13,6 +13,8 @@
   # Return the outputs schema that consumers expect
   outputs: |
     name: {{ .State.serviceName }}
+  expected_outputs:
+    - name
   # write the config file to the mounts directory
   files: |
     components/{{ .State.serviceName }}.yaml: |

--- a/score-compose/10-service.provisioners.yaml
+++ b/score-compose/10-service.provisioners.yaml
@@ -5,3 +5,5 @@
   outputs: |
     {{ $w := (index .WorkloadServices .Init.name) }}
     name: {{ $w.ServiceName | quote }}
+  expected_outputs:
+    - name


### PR DESCRIPTION
```
score-compose init \
    --no-sample \
    --provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/score-compose/10-redis-dapr-state-store.provisioners.yaml \
    --provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/score-compose/10-hpa.provisioners.yaml \
    --provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/score-compose/10-env.provisioners.yaml \
    --provisioners https://raw.githubusercontent.com/score-spec/community-provisioners/refs/heads/main/score-compose/10-service.provisioners.yaml
```

Before:
```
$ score-compose provisioners list
+---------------------------+---------+--------+---------+
|           TYPE            |  CLASS  | PARAMS | OUTPUTS |
+---------------------------+---------+--------+---------+
| dapr-state-store          | default |        |         |
+---------------------------+---------+--------+---------+
| environment               |         |        |         |
+---------------------------+---------+--------+---------+
| horizontal-pod-autoscaler | (any)   |        |         |
+---------------------------+---------+--------+---------+
| service                   | (any)   |        |         |
+---------------------------+---------+--------+---------+
```

After:
```
$ score-compose provisioners list
+---------------------------+---------+--------+---------+
|           TYPE            |  CLASS  | PARAMS | OUTPUTS |
+---------------------------+---------+--------+---------+
| dapr-state-store          | default |        | name    |
+---------------------------+---------+--------+---------+
| environment               |         |        |         |
+---------------------------+---------+--------+---------+
| horizontal-pod-autoscaler | (any)   |        |         |
+---------------------------+---------+--------+---------+
| service                   | (any)   |        | name    |
+---------------------------+---------+--------+---------+
```