### PR TITLE
Use `mirror.gcr.io/` to avoid DockerHub rate limits error while using community provisioners

### DIFF
--- a/examples/environment/score.yaml
+++ b/examples/environment/score.yaml
@@ -3,7 +3,7 @@ metadata:
   name: example
 containers:
   main:
-    image: stefanprodan/podinfo
+    image: ghcr.io/stefanprodan/podinfo:latest
     variables:
       TEST: ${resources.env.TEST}
 resources:

--- a/examples/hpa/score.yaml
+++ b/examples/hpa/score.yaml
@@ -3,7 +3,7 @@ metadata:
   name: example
 containers:
   main:
-    image: stefanprodan/podinfo
+    image: ghcr.io/stefanprodan/podinfo:latest
 resources:
   hpa:
     type: horizontal-pod-autoscaler

--- a/examples/redis-dapr-state-store/score.yaml
+++ b/examples/redis-dapr-state-store/score.yaml
@@ -3,7 +3,7 @@ metadata:
   name: example
 containers:
   main:
-    image: stefanprodan/podinfo
+    image: ghcr.io/stefanprodan/podinfo:latest
     variables:
       STATE_STORE: ${resources.state-store.name}
 resources:

--- a/examples/service/score-dep.yaml
+++ b/examples/service/score-dep.yaml
@@ -3,4 +3,4 @@ metadata:
   name: dep
 containers:
   main:
-    image: stefanprodan/podinfo
+    image: ghcr.io/stefanprodan/podinfo:latest

--- a/examples/service/score.yaml
+++ b/examples/service/score.yaml
@@ -3,7 +3,7 @@ metadata:
   name: example
 containers:
   main:
-    image: stefanprodan/podinfo
+    image: ghcr.io/stefanprodan/podinfo:latest
     variables:
       DEP_NAME: ${resources.dep.name}
 resources:

--- a/score-compose/10-redis-dapr-pubsub.provisioners.yaml
+++ b/score-compose/10-redis-dapr-pubsub.provisioners.yaml
@@ -42,7 +42,7 @@
     {{ .State.serviceName }}:
       labels:
         dev.score.compose.res.uid: {{ .Uid }}
-      image: redis:7-alpine
+      image: mirror.gcr.io/redis:7-alpine
       restart: always
       entrypoint: ["redis-server"]
       command: ["/usr/local/etc/redis/redis.conf"]

--- a/score-compose/10-redis-dapr-state-store.provisioners.yaml
+++ b/score-compose/10-redis-dapr-state-store.provisioners.yaml
@@ -47,7 +47,7 @@
     {{ .State.serviceName }}:
       labels:
         dev.score.compose.res.uid: {{ .Uid }}
-      image: redis:7-alpine
+      image: mirror.gcr.io/redis:7-alpine
       restart: always
       entrypoint: ["redis-server"]
       command: ["/usr/local/etc/redis/redis.conf"]

--- a/score-k8s/10-rabbitmq-dapr-pubsub.provisioners.yaml
+++ b/score-k8s/10-rabbitmq-dapr-pubsub.provisioners.yaml
@@ -45,7 +45,7 @@
           spec:
             containers:
               - name: rabbitmq
-                image: rabbitmq:3-management-alpine
+                image: mirror.gcr.io/rabbitmq:3-management-alpine
                 ports:
                   - name: amqp
                     containerPort: {{ .Init.port }}

--- a/score-k8s/10-redis-dapr-pubsub.provisioners.yaml
+++ b/score-k8s/10-redis-dapr-pubsub.provisioners.yaml
@@ -69,7 +69,7 @@
             automountServiceAccountToken: false
             containers:
             - name: redis
-              image: redis:7-alpine
+              image: mirror.gcr.io/redis:7-alpine
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:

--- a/score-k8s/10-redis-dapr-state-store.provisioners.yaml
+++ b/score-k8s/10-redis-dapr-state-store.provisioners.yaml
@@ -62,7 +62,7 @@
             automountServiceAccountToken: false
             containers:
             - name: redis
-              image: redis:7-alpine
+              image: mirror.gcr.io/redis:7-alpine
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:


### PR DESCRIPTION
Use `mirror.gcr.io/` to avoid DockerHub rate limits error while using community provisioners:
- https://docs.docker.com/docker-hub/usage/
- https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images
- https://devtron.ai/blog/dodging-docker-hub-rate-limits-the-ultimate-cheat-code-for-your-ci-cd-pipeline/

> Starting April 1, 2025, all users with a Pro, Team, or Business subscription will have unlimited Docker Hub pulls with fair use. Unauthenticated users and users with a free Personal account have the following pull limits:
> - Unauthenticated users: 10 pulls/hour
> - Authenticated users with a free account: 100 pulls/hour