### PR TITLE
Update `score-k8s/10-service.provisioners.yaml` - `service` fail if not found

### DIFF
--- a/score-k8s/10-service.provisioners.yaml
+++ b/score-k8s/10-service.provisioners.yaml
@@ -5,6 +5,7 @@
     name: {{ splitList "." .Id | last }}
   outputs: |
     {{ $w := (index .WorkloadServices .Init.name) }}
+    {{ if or (not $w) (not $w.ServiceName) }}{{ fail "unknown workload" }}{{ end }}
     name: {{ $w.ServiceName | quote }}
   expected_outputs: 
     - name


### PR DESCRIPTION
Update 10-service.provisioners.yaml - `service` fail if not found