### PR TITLE
expected_outputs for cmd provisioners with score-compose

### DIFF
--- a/dns/score-compose/10-dns-in-codespace.provisioners.yaml
+++ b/dns/score-compose/10-dns-in-codespace.provisioners.yaml
@@ -10,6 +10,6 @@
     URL=https://${HOST}
     OUTPUTS='{"resource_outputs":{"host":"%s", "url":"%s"}}'
     printf "$OUTPUTS" "$HOST" "$URL"
-  #expected_outputs:
-  #  - host
-  #  - url
+  expected_outputs:
+    - host
+    - url


### PR DESCRIPTION
Thanks to https://github.com/score-spec/score-compose/issues/279, now able to successfully do that:

```bash
score-compose init --provisioners dns/score-compose/10-dns-in-codespace.provisioners.yaml

score-compose provisioners list
```

```none
+-------------------+-------+------------------+----------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
|       TYPE        | CLASS |      PARAMS      |                                        OUTPUTS                                         |                                       DESCRIPTION                                       |
+-------------------+-------+------------------+----------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
| dns               | (any) |                  | host, url                                                                              | Get the forwarded port URL in current GitHub Codespace on port 8080                     |
+-------------------+-------+------------------+----------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
```