### PR TITLE
Add an Azurite-backed `azure-blob` provisioner for score-k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ score-k8s init --provisioners https://raw.githubusercontent.com/score-spec/commu
 
 | File | Type | Class | Params | Outputs | Description
 | ---- | ---- | ----- | ------ | ------- | -----------
+| 10-azurite-azure-blob.provisioners.yaml                    | `azure-blob`                | (any)   | `container`                                                           | `connection_string`, `account_name`, `account_key`, `blob_endpoint`, `container` | Generates an Azurite (Azure Storage emulator) `StatefulSet` and `Service` exposing the blob endpoint.
 | 10-rabbitmq-dapr-pubsub.provisioners.yaml                  | `dapr-pubsub`               | (any)   | (none)                                                                 | `name`                                  | Generates a Dapr PubSub `Component` pointing to a RabbitMQ `StatefulSet`.
 | 10-redis-dapr-pubsub.provisioners.yaml                     | `dapr-pubsub`               | (any)   | (none)                                                                 | `name`                                  | Generates a Dapr PubSub `Component` pointing to a Redis `StatefulSet`.
 | 10-redis-dapr-state-store.provisioners.yaml                | `dapr-state-store`          | (any)   | (none)                                                                 | `name`                                  | Generates a Dapr StateStore `Component` pointing to a Redis `StatefulSet`.

--- a/azure-blob/score-k8s/10-azurite-azure-blob.provisioners.yaml
+++ b/azure-blob/score-k8s/10-azurite-azure-blob.provisioners.yaml
@@ -1,0 +1,119 @@
+# Azurite (Azure Storage emulator) provisioner for the azure-blob resource type.
+# Runs Azurite in the cluster and gives the workload a connection string plus the
+# well-known dev-storage credentials, so apps using the Azure Blob SDK can work
+# against it locally without a real Azure Storage account.
+# See https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+- uri: template://community-provisioners/azurite-azure-blob
+  type: azure-blob
+  description: Generates an Azurite (Azure Storage emulator) StatefulSet and Service exposing the blob endpoint.
+  supported_params:
+    - container
+  init: |
+    blobPort: 10000
+    accountName: devstoreaccount1
+    accountKey: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+    defaultContainer: blob-{{ randAlphaNum 6 | lower }}
+  state: |
+    service: azurite-{{ .SourceWorkload }}-{{ substr 0 8 .Guid | lower }}
+    container: {{ dig "container" (.Params.container | default .Init.defaultContainer) .State | quote }}
+  outputs: |
+    connection_string: "DefaultEndpointsProtocol=http;AccountName={{ .Init.accountName }};AccountKey={{ .Init.accountKey }};BlobEndpoint=http://{{ .State.service }}:{{ .Init.blobPort }}/{{ .Init.accountName }};"
+    account_name: {{ .Init.accountName | quote }}
+    account_key: {{ .Init.accountKey | quote }}
+    blob_endpoint: "http://{{ .State.service }}:{{ .Init.blobPort }}/{{ .Init.accountName }}"
+    container: {{ .State.container | quote }}
+  expected_outputs:
+    - connection_string
+    - account_name
+    - account_key
+    - blob_endpoint
+    - container
+  manifests: |
+    - apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: {{ .State.service }}
+        {{ if ne .Namespace "" }}
+        namespace: {{ .Namespace }}
+        {{ end }}
+        annotations:
+          k8s.score.dev/source-workload: {{ .SourceWorkload }}
+          k8s.score.dev/resource-uid: {{ .Uid }}
+          k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
+      spec:
+        serviceName: {{ .State.service }}
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/instance: {{ .State.service }}
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/managed-by: score-k8s
+              app.kubernetes.io/name: {{ .State.service }}
+              app.kubernetes.io/instance: {{ .State.service }}
+          spec:
+            containers:
+              - name: azurite
+                image: mcr.microsoft.com/azure-storage/azurite:latest
+                command: ["azurite-blob"]
+                args:
+                  - --blobHost
+                  - 0.0.0.0
+                  - --blobPort
+                  - "{{ .Init.blobPort }}"
+                  - --location
+                  - /data
+                ports:
+                  - name: blob
+                    containerPort: {{ .Init.blobPort }}
+                volumeMounts:
+                  - name: data
+                    mountPath: /data
+                readinessProbe:
+                  tcpSocket:
+                    port: {{ .Init.blobPort }}
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - ALL
+            securityContext:
+              fsGroup: 1000
+        volumeClaimTemplates:
+          - metadata:
+              name: data
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: 1Gi
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: {{ .State.service }}
+        {{ if ne .Namespace "" }}
+        namespace: {{ .Namespace }}
+        {{ end }}
+        annotations:
+          k8s.score.dev/source-workload: {{ .SourceWorkload }}
+          k8s.score.dev/resource-uid: {{ .Uid }}
+          k8s.score.dev/resource-guid: {{ .Guid }}
+        labels:
+          app.kubernetes.io/managed-by: score-k8s
+          app.kubernetes.io/name: {{ .State.service }}
+          app.kubernetes.io/instance: {{ .State.service }}
+      spec:
+        selector:
+          app.kubernetes.io/instance: {{ .State.service }}
+        type: ClusterIP
+        ports:
+          - port: {{ .Init.blobPort }}
+            targetPort: {{ .Init.blobPort }}
+            name: blob

--- a/azure-blob/score-k8s/README.md
+++ b/azure-blob/score-k8s/README.md
@@ -1,0 +1,19 @@
+## For `10-azurite-azure-blob.provisioners.yaml`
+
+Runs [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite), the Azure Storage emulator, as a `StatefulSet` with a 1Gi volume, and exposes its blob endpoint through a `ClusterIP` Service on port `10000`. It's meant for local development against the Azure Blob SDK without provisioning a real Storage account.
+
+The workload gets these outputs:
+
+- `connection_string` - ready to drop into `AZURE_STORAGE_CONNECTION_STRING` or pass to `BlobServiceClient`.
+- `account_name`, `account_key` - Azurite's well-known dev account (`devstoreaccount1`).
+- `blob_endpoint` - `http://<service>:10000/devstoreaccount1`.
+- `container` - a container name for the workload to use. Override it with the `container` param.
+
+A couple of things worth knowing:
+
+- The account name and key are Azurite's [well-known credentials](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key). They're the same for every Azurite instance and are published in the docs, so treat them as a local-dev convenience, not as secrets.
+- Azurite starts empty. The `container` output is just a name - have your app create it on startup (`create_if_not_exists` / `createIfNotExists` exists in every Azure SDK), or run `az storage container create` against the endpoint once it's up.
+
+Prerequisites:
+- None beyond `score-k8s`. This is a template provisioner, so there's no `helm` or `yq` dependency.
+- To actually run it, apply the generated manifests to any cluster. If you don't have one, `.scripts/setup-kind-cluster.sh` spins up a local Kind cluster.

--- a/azure-blob/score.yaml
+++ b/azure-blob/score.yaml
@@ -1,0 +1,19 @@
+apiVersion: score.dev/v1b1
+metadata:
+  name: my-workload
+containers:
+  my-container:
+    image: busybox
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $AZURE_STORAGE_CONNECTION_STRING; sleep 5; done"]
+    variables:
+      AZURE_STORAGE_CONNECTION_STRING: "${resources.blob.connection_string}"
+      AZURE_STORAGE_ACCOUNT: "${resources.blob.account_name}"
+      AZURE_STORAGE_KEY: "${resources.blob.account_key}"
+      AZURE_BLOB_ENDPOINT: "${resources.blob.blob_endpoint}"
+      AZURE_BLOB_CONTAINER: "${resources.blob.container}"
+resources:
+  blob:
+    type: azure-blob
+    params:
+      container: my-workload-data


### PR DESCRIPTION
Adds an `azure-blob` resource type for `score-k8s`, backed by [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) so you can work against Azure Blob storage locally without a real Storage account.

The provisioner runs Azurite as a StatefulSet (blob service only, 1Gi volume) with a ClusterIP Service on port 10000, and hands the workload back a connection string plus the dev credentials. Outputs: `connection_string`, `account_name`, `account_key`, `blob_endpoint`, and `container`.

What's in here:
- `azure-blob/score-k8s/10-azurite-azure-blob.provisioners.yaml` - the provisioner
- `azure-blob/score.yaml` - a small sample workload that maps the outputs onto the usual Azure env vars
- `azure-blob/score-k8s/README.md` - usage notes
- `README.md` - new row in the score-k8s table

A couple of things for reviewers:
- The account name and key are Azurite's well-known dev values (`devstoreaccount1`), which are public in the Azure docs, so I emit them as plain outputs instead of wrapping them in a Secret.
- I don't pre-create a container. The `container` output is just a name for the app to create on first use (every Azure SDK has create-if-not-exists). Happy to add a setup Job instead if you'd rather it exist up front.

Tested locally with score-k8s 0.13.0: `init --no-sample --provisioners <file>` then `generate score.yaml` renders the StatefulSet, Service and workload env vars, resolves all five outputs, and stays stable when re-run.

Closes #36